### PR TITLE
Update frisquet-ERS-decode.ino

### DIFF
--- a/frisquet-ERS-decode/frisquet-ERS-decode.ino
+++ b/frisquet-ERS-decode/frisquet-ERS-decode.ino
@@ -72,10 +72,13 @@ void loop() {
           message = 0;
         }
       } else {
-        trame[0] = "";
-        trame[1] = "";
-        trame[2] = "";
-        message = 0;
+       	// Re-initialise la trame s'il n'y avait pas de données juste avant      
+        if ((message == 0) || (trame[message-1].length() < 200)) { 
+          trame[0] = "";
+          trame[1] = "";
+          trame[2] = "";
+          message = 0;
+        }      
       }
     }
     data_dispo = false;


### PR DESCRIPTION
Permet de capter toutes les trames, inclus celles-ci qui ont du bruit entre la premier, deuxième et troisième